### PR TITLE
Fixing variable type to store reload value

### DIFF
--- a/hw/watchdog/wdt_aspeed.c
+++ b/hw/watchdog/wdt_aspeed.c
@@ -75,13 +75,13 @@ static uint64_t aspeed_wdt_read(void *opaque, hwaddr offset, unsigned size)
 
 static void aspeed_wdt_reload(AspeedWDTState *s, bool pclk)
 {
-    uint32_t reload;
+    uint64_t reload;
 
     if (pclk) {
         reload = muldiv64(s->regs[WDT_RELOAD_VALUE], NANOSECONDS_PER_SECOND,
                           s->pclk_freq);
     } else {
-        reload = s->regs[WDT_RELOAD_VALUE] * 1000;
+        reload = s->regs[WDT_RELOAD_VALUE] * 1000UL;
     }
 
     if (aspeed_wdt_is_enabled(s)) {


### PR DESCRIPTION
32 bit integer too small to store nanosecond result for timer reload value.