### PR TITLE
aspeed: include build AT24X EEPROM devices

### DIFF
--- a/hw/arm/Kconfig
+++ b/hw/arm/Kconfig
@@ -367,6 +367,7 @@ config ASPEED_SOC
     select IBM_CFFPS
     select IR35221
     select APB2OPB_ASPEED
+    select AT24C
 
 config MPS2
     bool


### PR DESCRIPTION
By reason of the Yadro, Intel and many similar manufactures of BMC use a ATMEL AT24X EEPROM devices needs to include the AT24C device to ASPEED_SOC dependencies

Signed-off-by: Igor Kononenko <i.kononenko@yadro.com>
Change-Id: I7165a2e4914c907bd1f9d0f605793183829c1ef1